### PR TITLE
Add benchmark for clipping planes

### DIFF
--- a/benchmarks/bm_points.py
+++ b/benchmarks/bm_points.py
@@ -7,10 +7,10 @@ rng = np.random.default_rng()
 
 # An option to add 5 clipping planes to ensure that the clipping code is not
 # too slow
-five_clipping_planes = rng.random((5, 4), dtype='float32')
+five_clipping_planes = rng.random((5, 4), dtype='float32').tolist()
 # Twenty should exagerate the clipping code, though it is unclear if it is
 # representative of real workloads
-twenty_clipping_planes = rng.random((20, 4), dtype='float32')
+twenty_clipping_planes = rng.random((20, 4), dtype='float32').tolist()
 
 
 def benchmark_points(canvas, n_objects, n_verts, *, clipping_planes=None):

--- a/benchmarks/bm_points.py
+++ b/benchmarks/bm_points.py
@@ -5,9 +5,12 @@ from _benchmark import benchmark, run_all
 
 rng = np.random.default_rng()
 
-# An option to add 5 clipping planes to ensure that the clipping code is not too slow
-five_clipping_planes = rng.random((5, 4) dtype='float32')
-twenty_clipping_planes = rng.random((20, 4) dtype='float32')
+# An option to add 5 clipping planes to ensure that the clipping code is not
+# too slow
+five_clipping_planes = rng.random((5, 4), dtype='float32')
+# Twenty should exagerate the clipping code, though it is unclear if it is
+# representative of real workloads
+twenty_clipping_planes = rng.random((20, 4), dtype='float32')
 
 
 def benchmark_points(canvas, n_objects, n_verts, *, clipping_planes=None):

--- a/benchmarks/bm_points.py
+++ b/benchmarks/bm_points.py
@@ -3,14 +3,11 @@ import pygfx as gfx
 
 from _benchmark import benchmark, run_all
 
+rng = np.random.default_rng()
+
 # An option to add 5 clipping planes to ensure that the clipping code is not too slow
-clipping_planes = [
-    [0, 1, 0, 0],
-    [0, 0.5, 0, 0],
-    [1, 0, 0, 0],
-    [1, 1, 0, 0],
-    [2, 1, 0, 0],
-]
+five_clipping_planes = rng.random((5, 4) dtype='float32')
+twenty_clipping_planes = rng.random((20, 4) dtype='float32')
 
 
 def benchmark_points(canvas, n_objects, n_verts, *, clipping_planes=None):
@@ -58,9 +55,14 @@ def benchmark_points_1_100k(canvas):
     yield from benchmark_points(canvas, 1, 100_000)
 
 @benchmark
-def benchmark_points_1_100k_clipping_planes(canvas):
+def benchmark_points_1_100k_five_clipping_planes(canvas):
     # 1 points object with 100000 points
-    yield from benchmark_points(canvas, 1, 100_000, clipping_planes=clipping_planes)
+    yield from benchmark_points(canvas, 1, 100_000, clipping_planes=five_clipping_planes)
+
+@benchmark
+def benchmark_points_1_100k_twenty_clipping_planes(canvas):
+    # 1 points object with 100000 points
+    yield from benchmark_points(canvas, 1, 100_000, clipping_planes=twenty_clipping_planes)
 
 @benchmark
 def benchmark_points_100_1000(canvas):
@@ -69,9 +71,14 @@ def benchmark_points_100_1000(canvas):
 
 
 @benchmark
-def benchmark_points_100_1000_clipping_planes(canvas):
+def benchmark_points_100_1000_five_clipping_planes(canvas):
     # 100 points objects with 1000 points each
-    yield from benchmark_points(canvas, 100, 1000, clipping_planes=clipping_planes)
+    yield from benchmark_points(canvas, 100, 1000, clipping_planes=five_clipping_planes)
+
+@benchmark
+def benchmark_points_100_1000_twenty_clipping_planes(canvas):
+    # 100 points objects with 1000 points each
+    yield from benchmark_points(canvas, 100, 1000, clipping_planes=twenty_clipping_planes)
 
 
 @benchmark
@@ -81,9 +88,14 @@ def benchmark_points_1000_100(canvas):
 
 
 @benchmark
-def benchmark_points_1000_100_clipping_planes(canvas):
+def benchmark_points_1000_100_five_clipping_planes(canvas):
     # 1000 points objects with 100 points each
-    yield from benchmark_points(canvas, 1000, 100, clipping_planes=clipping_planes)
+    yield from benchmark_points(canvas, 1000, 100, clipping_planes=five_clipping_planes)
+
+@benchmark
+def benchmark_points_1000_100_twenty_clipping_planes(canvas):
+    # 1000 points objects with 100 points each
+    yield from benchmark_points(canvas, 1000, 100, clipping_planes=twenty_clipping_planes)
 
 
 # A simple case, and a case of drawing 1M
@@ -95,9 +107,14 @@ def benchmark_points_10_10(canvas):
     yield from benchmark_points(canvas, 10, 10)
 
 @benchmark
-def benchmark_points_10_10_clipping_planes(canvas):
+def benchmark_points_10_10_five_clipping_planes(canvas):
     # 10 points objects with 10 points each
-    yield from benchmark_points(canvas, 10, 10, clipping_planes=clipping_planes)
+    yield from benchmark_points(canvas, 10, 10, clipping_planes=five_clipping_planes)
+
+@benchmark
+def benchmark_points_10_10_twenty_clipping_planes(canvas):
+    # 10 points objects with 10 points each
+    yield from benchmark_points(canvas, 10, 10, clipping_planes=twenty_clipping_planes)
 
 
 @benchmark
@@ -106,9 +123,15 @@ def benchmark_points_1_1m(canvas):
     yield from benchmark_points(canvas, 1, 1_000_000)
 
 @benchmark
-def benchmark_points_1_1m_clipping_planes(canvas):
+def benchmark_points_1_1m_five_clipping_planes(canvas):
     # 1 points object with 1mpoints
-    yield from benchmark_points(canvas, 1, 1_000_000, clipping_planes=clipping_planes)
+    yield from benchmark_points(canvas, 1, 1_000_000, clipping_planes=five_clipping_planes)
+
+@benchmark
+def benchmark_points_1_1m_twenty_clipping_planes(canvas):
+    # 1 points object with 1mpoints
+    yield from benchmark_points(canvas, 1, 1_000_000, clipping_planes=twenty_clipping_planes)
+
 
 if __name__ == "__main__":
     from wgpu.gui.auto import WgpuCanvas

--- a/benchmarks/bm_points.py
+++ b/benchmarks/bm_points.py
@@ -3,8 +3,17 @@ import pygfx as gfx
 
 from _benchmark import benchmark, run_all
 
+# An option to add 5 clipping planes to ensure that the clipping code is not too slow
+clipping_planes = [
+    [0, 1, 0, 0],
+    [0, 0.5, 0, 0],
+    [1, 0, 0, 0],
+    [1, 1, 0, 0],
+    [2, 1, 0, 0],
+]
 
-def benchmark_points(canvas, n_objects, n_verts):
+
+def benchmark_points(canvas, n_objects, n_verts, *, clipping_planes=None):
 
     renderer = gfx.WgpuRenderer(canvas, blend_mode="ordered2")
     renderer.measure_gpu_times = True
@@ -18,7 +27,10 @@ def benchmark_points(canvas, n_objects, n_verts):
     for i in range(n_objects):
         points = gfx.Points(
             gfx.Geometry(positions=positions),
-            gfx.PointsMaterial(size=20),
+            gfx.PointsMaterial(
+                size=20,
+                clipping_planes=clipping_planes,
+            ),
         )
         points.local.y = 500 * (i - 0.5 * n_objects) / n_objects
         scene.add(points)
@@ -45,6 +57,10 @@ def benchmark_points_1_100k(canvas):
     # 1 points object with 100000 points
     yield from benchmark_points(canvas, 1, 100_000)
 
+@benchmark
+def benchmark_points_1_100k_clipping_planes(canvas):
+    # 1 points object with 100000 points
+    yield from benchmark_points(canvas, 1, 100_000, clipping_planes=clipping_planes)
 
 @benchmark
 def benchmark_points_100_1000(canvas):
@@ -53,9 +69,21 @@ def benchmark_points_100_1000(canvas):
 
 
 @benchmark
+def benchmark_points_100_1000_clipping_planes(canvas):
+    # 100 points objects with 1000 points each
+    yield from benchmark_points(canvas, 100, 1000, clipping_planes=clipping_planes)
+
+
+@benchmark
 def benchmark_points_1000_100(canvas):
     # 1000 points objects with 100 points each
     yield from benchmark_points(canvas, 1000, 100)
+
+
+@benchmark
+def benchmark_points_1000_100_clipping_planes(canvas):
+    # 1000 points objects with 100 points each
+    yield from benchmark_points(canvas, 1000, 100, clipping_planes=clipping_planes)
 
 
 # A simple case, and a case of drawing 1M
@@ -66,12 +94,21 @@ def benchmark_points_10_10(canvas):
     # 10 points objects with 10 points each
     yield from benchmark_points(canvas, 10, 10)
 
+@benchmark
+def benchmark_points_10_10_clipping_planes(canvas):
+    # 10 points objects with 10 points each
+    yield from benchmark_points(canvas, 10, 10, clipping_planes=clipping_planes)
+
 
 @benchmark
 def benchmark_points_1_1m(canvas):
     # 1 points object with 1mpoints
     yield from benchmark_points(canvas, 1, 1_000_000)
 
+@benchmark
+def benchmark_points_1_1m_clipping_planes(canvas):
+    # 1 points object with 1mpoints
+    yield from benchmark_points(canvas, 1, 1_000_000, clipping_planes=clipping_planes)
 
 if __name__ == "__main__":
     from wgpu.gui.auto import WgpuCanvas


### PR DESCRIPTION
For https://github.com/pygfx/pygfx/pull/804

On `pygfx` main:

```
Detected skylake derivative running on mesa i915. Clears to srgb textures will use manual shader clears.
                 points_1_100k (10x) - cpu: 32.31 ms
 points_1_100k_clipping_planes (10x) - cpu: 51.79 ms
               points_100_1000 (10x) - cpu: 23.83 ms
points_100_1000_clipping_planes (10x) - cpu: 43.29 ms
               points_1000_100 (10x) - cpu: 54.59 ms
points_1000_100_clipping_planes (10x) - cpu: 74.00 ms
                  points_10_10 (10x) - cpu:  5.86 ms
  points_10_10_clipping_planes (10x) - cpu:  5.52 ms
                   points_1_1m (10x) - cpu:288.64 ms
   points_1_1m_clipping_planes (10x) - cpu:483.61 ms
```

On the proposed SDF changes:
```
 $ python bm_points.py
Detected skylake derivative running on mesa i915. Clears to srgb textures will use manual shader clears.
                 points_1_100k (10x) - cpu: 35.08 ms
 points_1_100k_clipping_planes (10x) - cpu: 44.80 ms
               points_100_1000 (10x) - cpu: 23.68 ms
points_100_1000_clipping_planes (10x) - cpu: 37.57 ms
               points_1000_100 (10x) - cpu: 49.29 ms
points_1000_100_clipping_planes (10x) - cpu: 54.42 ms
                  points_10_10 (10x) - cpu:  5.47 ms
  points_10_10_clipping_planes (10x) - cpu:  5.05 ms
                   points_1_1m (10x) - cpu:287.53 ms
   points_1_1m_clipping_planes (10x) - cpu:412.25 ms
```

so it seems quite measurable.