### PR TITLE
Add benchmarks for transforms

### DIFF
--- a/benchmarks/bm_transforms.py
+++ b/benchmarks/bm_transforms.py
@@ -1,0 +1,46 @@
+from pygfx import Group
+from _benchmark import benchmark, run_all
+
+
+@benchmark(20)
+def bm_transforms_100_children(canvas):
+    group = Group()
+    for i in range(100):
+        group.add(Group())
+
+    yield
+
+    while True:
+        group.local.x += 1
+        yield
+
+@benchmark(20)
+def bm_transforms_1000_children(canvas):
+    group = Group()
+    for i in range(1000):
+        group.add(Group())
+
+    yield
+
+    while True:
+        group.local.x += 1
+        yield
+
+@benchmark(20)
+def bm_transforms_1000_children_with_50_grandchildren(canvas):
+    group = Group()
+    for i in range(1000):
+        g = Group()
+        group.add(g)
+        for _ in range(50):
+            g.add(Group())
+
+    yield
+
+    while True:
+        group.local.x += 1
+        yield
+
+
+if __name__ == "__main__":
+    run_all(globals())


### PR DESCRIPTION
xref: https://github.com/pygfx/pygfx/pull/971

Linux +  Intel(R) Core(TM) Ultra 7 165U (Ubuntu 24.04 + X11)
On 0.7.0:
```
$python benchmarks/bm_transforms.py
    bm_transforms_100_children (20x) - cpu:  0.19 ms
   bm_transforms_1000_children (20x) - cpu:  1.87 ms
```

On main `v0.7.0-27-g469043c`:
```
$ python benchmarks/bm_transforms.py
    bm_transforms_100_children (20x) - cpu:  0.01 ms
   bm_transforms_1000_children (20x) - cpu:  0.04 ms
bm_transforms_1000_children_with_50_grandchildren (20x) - cpu:  7.92 ms
```

On `transform-slots`
```
$ python benchmarks/bm_transforms.py
    bm_transforms_100_children (20x) - cpu:  0.01 ms
   bm_transforms_1000_children (20x) - cpu:  0.04 ms
bm_transforms_1000_children_with_50_grandchildren (20x) - cpu:  2.87 ms
```